### PR TITLE
upgrade io.spring.initializr version to support spring release numbering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
             <dependency>
                 <groupId>io.spring.initializr</groupId>
                 <artifactId>initializr-bom</artifactId>
-                <version>0.8.0.RELEASE</version>
+                <version>0.10.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
version 0.8.0 does not support release formant 0.0.0-Release, this is fixed in a newer version

#1 